### PR TITLE
rename to only required, resolve overrides, default value

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,8 +25,8 @@ type Config struct {
 	// default in NewConfig but can be emptied to remove the comment altogether.
 	TODOComment string
 
-	// Minimal mode only renders properties which are required and have no default value
-	Minimal bool
+	// OnlyRequired properties are returned
+	OnlyRequired bool
 }
 
 // forProperty will construct a config object for the given property, allows for recursive
@@ -45,7 +45,7 @@ func (c *Config) forProperty(propertyName string) *Config {
 
 	return &Config{
 		TODOComment:    c.TODOComment,
-		Minimal:        c.Minimal,
+		OnlyRequired:   c.OnlyRequired,
 		ValueOverrides: valueOverrides,
 	}
 }
@@ -83,10 +83,9 @@ func WithTODOComment(comment string) Option {
 	}
 }
 
-// Minimal allows you to only return the minimal yaml file that needs to be filled in
-// by the user (only required properties with no default value)
-func Minimal() Option {
+// OnlyRequired properties are returned
+func OnlyRequired() Option {
 	return func(c *Config) {
-		c.Minimal = true
+		c.OnlyRequired = true
 	}
 }

--- a/config.go
+++ b/config.go
@@ -56,9 +56,9 @@ func (c *Config) forProperty(propertyName string) *Config {
 	}
 
 	return &Config{
-		TODOComment: c.TODOComment,
+		TODOComment:    c.TODOComment,
 		OnlyRequired:   c.OnlyRequired,
-		LineLength:  c.LineLength,
+		LineLength:     c.LineLength,
 		ValueOverrides: valueOverrides,
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -43,14 +43,14 @@ func TestConfig_ForProperty_ReturnsExpectedConfig(t *testing.T) {
 				ValueOverrides: map[string]any{"bar": "baz"},
 			},
 		},
-		"subproperty is returned with minimal=true if set on parent": {
+		"subproperty is returned with OnlyRequired=true if set on parent": {
 			input: &Config{
-				Minimal: true,
+				OnlyRequired: true,
 			},
 			propertyName: "foo",
 
 			expected: &Config{
-				Minimal:        true,
+				OnlyRequired:   true,
 				ValueOverrides: map[string]any{},
 			},
 		},

--- a/config_test.go
+++ b/config_test.go
@@ -17,16 +17,16 @@ func TestConfig_ForProperty_ReturnsExpectedConfig(t *testing.T) {
 	}{
 		"copies over 'simple' values from parent config": {
 			input: &Config{
-				TODOComment: "abc",
-				LineLength:  20,
-				OnlyRequired:     true,
+				TODOComment:  "abc",
+				LineLength:   20,
+				OnlyRequired: true,
 			},
 			propertyName: "foo",
 
 			expected: &Config{
 				TODOComment:    "abc",
 				LineLength:     20,
-				OnlyRequired:        true,
+				OnlyRequired:   true,
 				ValueOverrides: map[string]any{},
 			},
 		},

--- a/schema.go
+++ b/schema.go
@@ -61,41 +61,33 @@ func (j *JSONSchema) ScheYAML(cfg *Config) *yaml.Node {
 		result.Kind = yaml.MappingNode
 		properties := j.alphabeticalProperties()
 
-		// only keep required properties
-		if cfg.Minimal {
-			var requiredProperties []string
-			for _, property := range properties {
-				if j.Default == nil && slices.Contains(j.Required, property) {
-					requiredProperties = append(requiredProperties, property)
-				}
-			}
-			properties = requiredProperties
-
-			if len(properties) == 0 {
-				return result
+		var requiredProperties []string
+		for _, property := range properties {
+			if slices.Contains(j.Required, property) {
+				requiredProperties = append(requiredProperties, property)
 			}
 		}
 
-		result.Content = make([]*yaml.Node, len(properties)*yamlNodesPerField)
-
-		for index, propertyName := range properties {
+		result.Content = []*yaml.Node{}
+		for _, propertyName := range properties {
 			property := j.Properties[propertyName]
+			overrideValue, hasOverrideValue := cfg.overrideFor(propertyName)
+			if cfg.OnlyRequired && !hasOverrideValue && !slices.Contains(requiredProperties, propertyName) {
+				continue
+			}
 
 			// The property name node
-			result.Content[index*yamlNodesPerField] = &yaml.Node{
+			result.Content = append(result.Content, &yaml.Node{
 				Kind:        yaml.ScalarNode,
 				Value:       propertyName,
 				HeadComment: property.formatHeadComment(),
-			}
+			})
 
-			// Skip recursing further and override the value with whatever the config says
-			if overrideValue, ok := cfg.overrideFor(propertyName); ok {
-				// The property value node
-				result.Content[index*yamlNodesPerField+1] = &yaml.Node{
+			if hasOverrideValue {
+				result.Content = append(result.Content, &yaml.Node{
 					Kind:  yaml.ScalarNode,
 					Value: fmt.Sprint(overrideValue),
-				}
-
+				})
 				continue
 			}
 
@@ -104,7 +96,7 @@ func (j *JSONSchema) ScheYAML(cfg *Config) *yaml.Node {
 			if valueNode.Content == nil && valueNode.Kind == yaml.MappingNode {
 				valueNode.Value = "{}"
 			}
-			result.Content[index*yamlNodesPerField+1] = valueNode
+			result.Content = append(result.Content, valueNode)
 		}
 
 	case TypeArray:

--- a/schema_test.go
+++ b/schema_test.go
@@ -49,7 +49,7 @@ func TestJSONSchemaObject_YAMLExample_ReturnsExpectedMinimalVersion(t *testing.T
 	require.NoError(t, err)
 
 	cfg := NewConfig()
-	cfg.Minimal = true
+	cfg.OnlyRequired = true
 
 	// Act
 	result := schemaObject.ScheYAML(cfg)

--- a/testdata/test-schema-required-output.yaml
+++ b/testdata/test-schema-required-output.yaml
@@ -1,4 +1,6 @@
-nestedNotRequiredProperty: {}
-nestedRequiredProperty:
-    requiredProperty: null # TODO: Fill this in
 requiredProperty: null # TODO: Fill this in
+requiredPropertyMapping:
+    requiredProperty: null # TODO: Fill this in
+    requiredPropertyWithDefault: default
+requiredPropertyMappingWithoutRequiredChildren: {}
+requiredPropertyWithDefault: default

--- a/testdata/test-schema-required.json
+++ b/testdata/test-schema-required.json
@@ -4,35 +4,46 @@
     "requiredProperty": {
       "type": "string"
     },
+    "requiredPropertyWithDefault": {
+      "type": "string",
+      "default": "default"
+    },
     "notRequiredProperty": {
       "type": "string"
     },
-    "nestedRequiredProperty": {
+    "requiredPropertyMapping": {
       "type": "object",
       "properties": {
         "requiredProperty": {
           "type": "string"
+        },
+        "requiredPropertyWithDefault": {
+          "type": "string",
+          "default": "default"
         },
         "notRequiredProperty": {
           "type": "string"
         }
       },
       "required": [
-        "requiredProperty"
+        "requiredProperty",
+        "requiredPropertyWithDefault"
       ]
     },
-    "nestedNotRequiredProperty": {
+    "requiredPropertyMappingWithoutRequiredChildren": {
       "type": "object",
       "properties": {
         "notRequiredProperty": {
           "type": "string"
         }
-      }
+      },
+      "required": []
     }
   },
   "required": [
     "requiredProperty",
-    "nestedRequiredProperty",
-    "nestedNotRequiredProperty"
+    "requiredPropertyWithDefault",
+    "requiredPropertyMapping",
+    "requiredPropertyMappingWithoutRequiredChildren"
   ]
 }


### PR DESCRIPTION
PR that fixes some of the issues as a result of releasing 0.0.4

- renames `Minimal` to `OnlyRequired` to better emphasise that this is the intended use of the setting
- if set, only renders required properties (both with and without defaults)
- handle override vars correctly
- fix regression introduced when the parent had no default value